### PR TITLE
Apply attributes on inv change + quick move stack

### DIFF
--- a/src/main/java/net/hyper_pigeon/horseshoes/mixin/AbstractHorseEntityMixin.java
+++ b/src/main/java/net/hyper_pigeon/horseshoes/mixin/AbstractHorseEntityMixin.java
@@ -18,32 +18,40 @@ import net.minecraft.nbt.NbtOps;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(AbstractHorseEntity.class)
 public abstract class AbstractHorseEntityMixin extends AnimalEntity implements HorseshoeWearingMob, InventoryChangedListener {
+
+    @Unique
     protected SimpleInventory horseshoe = new SimpleInventory(1);
 
     protected AbstractHorseEntityMixin(EntityType<? extends AnimalEntity> entityType, World world) {
         super(entityType, world);
     }
 
+    @Unique
     public boolean hasHorseshoes() {
         return !horseshoe.isEmpty() && (horseshoe.getStack(getHorseshoesSlot()).getItem() instanceof HorseshoesItem);
     }
 
+    @Unique
     public int getHorseshoesSlot(){
         return 0;
     }
 
-    @Inject(method = "tick", at = @At("HEAD"))
+    @Inject(method = "onChestedStatusChanged", at = @At("TAIL"))
+    public void registerInventory(CallbackInfo ci) {
+        horseshoe.addListener(this);
+    }
+
+    @Inject(method = "onInventoryChanged", at = @At("TAIL"))
     public void handleHorseshoes(CallbackInfo ci){
         applyHorseshoesBonus();
     }
-
-
 
     public void applyHorseshoesBonus() {
         boolean bl = this.hasHorseshoes();

--- a/src/main/java/net/hyper_pigeon/horseshoes/mixin/HorseScreenHandlerMixin.java
+++ b/src/main/java/net/hyper_pigeon/horseshoes/mixin/HorseScreenHandlerMixin.java
@@ -14,16 +14,22 @@ import net.minecraft.screen.HorseScreenHandler;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.screen.slot.ArmorSlot;
+import net.minecraft.screen.slot.Slot;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(HorseScreenHandler.class)
 public abstract class HorseScreenHandlerMixin extends ScreenHandler {
 
+    @Unique
     private SimpleInventory horseshoeInventory;
 
     protected HorseScreenHandlerMixin(@Nullable ScreenHandlerType<?> type, int syncId) {
@@ -55,6 +61,35 @@ public abstract class HorseScreenHandlerMixin extends ScreenHandler {
     @Inject(method = "onClosed", at = @At("TAIL"))
     public void onClosed(PlayerEntity player, CallbackInfo ci) {
         this.horseshoeInventory.onClose(player);
+    }
+
+    @Inject(method = "quickMove", at = @At("HEAD"), cancellable = true)
+    public void horseshoeQuickMove(PlayerEntity player, int slot, CallbackInfoReturnable<ItemStack> cir) {
+        Slot slot2 = this.slots.get(slot);
+        if (slot2 != null && slot2.hasStack()) {
+            ItemStack itemStack2 = slot2.getStack();
+            ItemStack itemStack = itemStack2.copy();
+            if (slot == 38) {
+                if (!this.insertItem(itemStack2, 2, this.slots.size(), true)) {
+                    cir.setReturnValue(ItemStack.EMPTY);
+                } else {
+                    cir.setReturnValue(itemStack);
+                }
+                cir.cancel();
+            } else if (this.getSlot(38).canInsert(itemStack2) && !this.getSlot(38).hasStack()) {
+                if (!this.insertItem(itemStack2, 38, 39, false)) {
+                    cir.setReturnValue(ItemStack.EMPTY);
+                } else {
+                    cir.setReturnValue(itemStack);
+                    if (itemStack2.isEmpty()) {
+                        slot2.setStack(ItemStack.EMPTY);
+                    } else {
+                        slot2.markDirty();
+                    }
+                }
+                cir.cancel();
+            }
+        }
     }
 
 }

--- a/src/main/java/net/hyper_pigeon/horseshoes/mixin/HorseScreenMixin.java
+++ b/src/main/java/net/hyper_pigeon/horseshoes/mixin/HorseScreenMixin.java
@@ -12,6 +12,7 @@ import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -19,6 +20,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(HorseScreen.class)
 public abstract class HorseScreenMixin extends HandledScreen {
 
+    @Unique
     private static final Identifier TEXTURE = Identifier.of("horseshoes","textures/gui/container/horse.png");
 
     @Final


### PR DESCRIPTION
Firstly changes the logic for applying a an attribute (back) to the inventory change event. For this to work, the horseshoe inv needs to be registered.

Secondly, I also took a look at the quick move stack logic, so horseshoes can be shift clicked in and out of the slot. Should close #11 .